### PR TITLE
Bump Protobuf to v3.20.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,6 +28,7 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
+
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
 scala_repositories()
 register_toolchains("//:scala_toolchain")
@@ -35,6 +36,7 @@ register_toolchains("//:scala_toolchain")
 load("//3rdparty:workspace.bzl", "maven_dependencies")
 
 maven_dependencies()
+
 
 load("//3rdparty:target_file.bzl", "build_external_workspace")
 build_external_workspace(name = "third_party")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,9 +12,9 @@ git_repository(
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "1e622ce4b84b88b6d2cdf1db38d1a634fe2392d74f0b7b74ff98f3a51838ee53",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.8.0.zip"],
-    strip_prefix = "protobuf-3.8.0",
+    sha256 = "662879e41508a5ecce3be2c65563a8fac3301a48adef3113913ec4010f405a33",
+    strip_prefix = "protobuf-3.20.1",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.20.1.zip"],
 )
 
 http_archive(
@@ -28,7 +28,6 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
-
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
 scala_repositories()
 register_toolchains("//:scala_toolchain")
@@ -36,7 +35,6 @@ register_toolchains("//:scala_toolchain")
 load("//3rdparty:workspace.bzl", "maven_dependencies")
 
 maven_dependencies()
-
 
 load("//3rdparty:target_file.bzl", "build_external_workspace")
 build_external_workspace(name = "third_party")


### PR DESCRIPTION
A dependency in the existing protobuf version (v3.8.0) is no longer
resolvable (zlip 1.2.10), bumping to a compatible semver release that
resolves this issue.