### PR TITLE
Fix zlib issue

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,9 +12,9 @@ git_repository(
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "1e622ce4b84b88b6d2cdf1db38d1a634fe2392d74f0b7b74ff98f3a51838ee53",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.8.0.zip"],
-    strip_prefix = "protobuf-3.8.0",
+    sha256 = "662879e41508a5ecce3be2c65563a8fac3301a48adef3113913ec4010f405a33",
+    strip_prefix = "protobuf-3.20.1",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.20.1.zip"],
 )
 
 http_archive(


### PR DESCRIPTION
I was running into the following error, while trying to run bazel run //:parse -- generate -r pwd -s 3rdparty/workspace.bzl -d dependencies.yaml. It happens because this project depends on version 3.8.0 of com_google_protobuf which in turn depends on zlib. The particular zlib url used in version 3.8.0 is no longer active.

```
ERROR: An error occurred during the fetch of repository 'zlib':
   Traceback (most recent call last):
	File "/home/ubuntu/.cache/bazel/_bazel_ubuntu/b26ed7439bb0d97834fc365137090839/external/bazel_tools/tools/build_defs/repo/http.bzl", line 111, column 45, in _http_archive_impl
		download_info = ctx.download_and_extract(
Error in download_and_extract: java.io.IOException: Error downloading [https://zlib.net/zlib-1.2.11.tar.gz] to /home/ubuntu/.cache/bazel/_bazel_ubuntu/b26ed7439bb0d97834fc365137090839/external/zlib/zlib-1.2.11.tar.gz: GET returned 404 Not Found
ERROR: /home/ubuntu/.cache/bazel/_bazel_ubuntu/b26ed7439bb0d97834fc365137090839/external/com_google_protobuf/BU
```