### PR TITLE
Fix a bug in refactoring GradleResolver

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
@@ -110,12 +110,13 @@ object MakeDeps {
         lazy val coursierResolver =
           new CoursierResolver(model.getOptions.getResolvers, ec, 3600.seconds, resolverCachePath)
 
-        resolve(
-          model,
-          new GradleResolver(
+        val resolver = new GradleResolver(
             model.getOptions.getVersionConflictPolicy,
             g,
-            { ls => coursierResolver.run(coursierResolver.getShas(ls)) }))
+            { ls => coursierResolver.run(coursierResolver.getShas(ls)) })
+        // Note: this branch fully defers to GradleResolver and not
+        // the private resolve(model, resolver) method here
+        resolver.resolve(model)
     }
 
   private type Res = (


### PR DESCRIPTION
the gradle resolver code *looks* superficially like the other resolvers, but it actually is not the same and has a different (but very similarly named) code path.

Clearly we need more tests and also possibly rethink the design.