### PR TITLE
Allow sha-file to be optional

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/Commands.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Commands.scala
@@ -60,7 +60,7 @@ object Command {
       repoRoot: Path,
       depsFile: String,
       resolvedOutput: Option[String],
-      shaFile: String,
+      shaFile: Option[String],
       targetFile: Option[String],
       buildifier: Option[String],
       pomFile: Option[String],
@@ -73,8 +73,8 @@ object Command {
     def absDepsFile: File =
       new File(repoRoot.toFile, depsFile)
 
-    def shaFilePath: String =
-      new File(shaFile).toString
+    def shaFilePath: Option[String] =
+      shaFile.map(new File(_).toString)
   }
   val generate = DCommand("generate", "generate transitive bazel targets") {
     val repoRoot = Opts.option[Path](
@@ -102,8 +102,7 @@ object Command {
       "sha-file",
       short = "s",
       metavar = "sha-file",
-      help = "relative path to the sha lock file (usually called workspace.bzl).")
-
+      help = "relative path to the sha lock file (usually called workspace.bzl).").orNone
 
     val targetFile = Opts.option[String](
       "target-file",


### PR DESCRIPTION
This is a follow up to: https://github.com/bazeltools/bazel-deps/pull/327

which made `-s` or `--sha-file` required as an option. We no longer use that so I had to make that optional again.

until we fix the CI:

```
oboykin@Oscars-MacBook-Pro bazel-deps % git rev-parse HEAD 
749b4dc151a9f01679f72666a5eaa645e53e09a8
oboykin@Oscars-MacBook-Pro bazel-deps % ./bazel test //...
DEBUG: Rule 'io_bazel_rules_scala' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1579112787 +0200"
DEBUG: Repository io_bazel_rules_scala instantiated at:
  /Users/oboykin/code/bazel-deps/WORKSPACE:19:15: in <toplevel>
Repository rule git_repository defined at:
  /private/var/tmp/_bazel_oboykin/4958ed22950b939e87bcc4e07cde8f11/external/bazel_tools/tools/build_defs/repo/git.bzl:199:33: in <toplevel>
INFO: Analyzed 102 targets (0 packages loaded, 0 targets configured).
INFO: Found 94 targets and 8 test targets...
INFO: Elapsed time: 0.077s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
//test/scala/com/github/johnynek/bazel_deps:coursier_test       (cached) PASSED in 14.6s
//test/scala/com/github/johnynek/bazel_deps:createpomtest       (cached) PASSED in 7.9s
//test/scala/com/github/johnynek/bazel_deps:graphtest           (cached) PASSED in 5.9s
//test/scala/com/github/johnynek/bazel_deps:modeltest           (cached) PASSED in 6.0s
//test/scala/com/github/johnynek/bazel_deps:normalizertest      (cached) PASSED in 6.1s
//test/scala/com/github/johnynek/bazel_deps:parsegenerateddoctest (cached) PASSED in 33.6s
//test/scala/com/github/johnynek/bazel_deps:parsetest           (cached) PASSED in 6.0s
//test/scala/com/github/johnynek/bazel_deps:parsetestcases      (cached) PASSED in 5.8s

Executed 0 out of 8 tests: 8 tests pass.
INFO: Build completed successfully, 1 total action
oboykin@Oscars-MacBook-Pro bazel-deps % ./bazel build //...
DEBUG: Rule 'io_bazel_rules_scala' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1579112787 +0200"
DEBUG: Repository io_bazel_rules_scala instantiated at:
  /Users/oboykin/code/bazel-deps/WORKSPACE:19:15: in <toplevel>
Repository rule git_repository defined at:
  /private/var/tmp/_bazel_oboykin/4958ed22950b939e87bcc4e07cde8f11/external/bazel_tools/tools/build_defs/repo/git.bzl:199:33: in <toplevel>
INFO: Analyzed 102 targets (0 packages loaded, 0 targets configured).
INFO: Found 102 targets...
INFO: Elapsed time: 0.071s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
```