### PR TITLE
Validate options to error on ignored options

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/Commands.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Commands.scala
@@ -56,7 +56,7 @@ sealed abstract class Command {
 }
 
 object Command {
-  sealed abstract class Gen extends Command {
+  sealed abstract class GenerateLike extends Command {
     def absDepsFile: File
     def buildifier: Option[String]
     def depsFile: String
@@ -73,7 +73,7 @@ object Command {
       pomFile: Option[String],
       verbosity: Verbosity,
       disable3rdPartyInRepo: Boolean
-  ) extends Gen {
+  ) extends GenerateLike {
 
     def enable3rdPartyInRepo: Boolean = !disable3rdPartyInRepo
     def absDepsFile: File =
@@ -89,7 +89,7 @@ object Command {
       shaFile: String,
       buildifier: Option[String],
       verbosity: Verbosity
-  ) extends Gen {
+  ) extends GenerateLike {
     def absDepsFile: File =
       new File(repoRoot.toFile, depsFile)
 

--- a/src/scala/com/github/johnynek/bazel_deps/Commands.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Commands.scala
@@ -56,6 +56,13 @@ sealed abstract class Command {
 }
 
 object Command {
+  sealed abstract class Gen extends Command {
+    def absDepsFile: File
+    def buildifier: Option[String]
+    def depsFile: String
+    def repoRoot: Path
+  }
+
   case class Generate(
       repoRoot: Path,
       depsFile: String,
@@ -64,10 +71,9 @@ object Command {
       targetFile: Option[String],
       buildifier: Option[String],
       pomFile: Option[String],
-      checkOnly: Boolean,
       verbosity: Verbosity,
       disable3rdPartyInRepo: Boolean
-  ) extends Command {
+  ) extends Gen {
 
     def enable3rdPartyInRepo: Boolean = !disable3rdPartyInRepo
     def absDepsFile: File =
@@ -76,6 +82,20 @@ object Command {
     def shaFilePath: Option[String] =
       shaFile.map(new File(_).toString)
   }
+
+  case class CheckGen(
+      repoRoot: Path,
+      depsFile: String,
+      shaFile: String,
+      buildifier: Option[String],
+      verbosity: Verbosity
+  ) extends Gen {
+    def absDepsFile: File =
+      new File(repoRoot.toFile, depsFile)
+
+    def shaFilePath: String = new File(shaFile).toString
+  }
+
   val generate = DCommand("generate", "generate transitive bazel targets") {
     val repoRoot = Opts.option[Path](
       "repo-root",
@@ -102,7 +122,7 @@ object Command {
       "sha-file",
       short = "s",
       metavar = "sha-file",
-      help = "relative path to the sha lock file (usually called workspace.bzl).").orNone
+      help = "relative path to the sha lock file (usually called workspace.bzl).")
 
     val targetFile = Opts.option[String](
       "target-file",
@@ -124,14 +144,23 @@ object Command {
 
     val checkOnly = Opts.flag(
       "check-only",
-      help = "if set, the generated files are checked against the existing files but are not written; exits 0 if the files match").orFalse
-
+      help = "if set, the generated BUILD files are checked against the existing files but are not written; exits 0 if the files match")
 
     val disable3rdPartyInRepos = Opts.flag(
       "disable-3rdparty-in-repo",
       help = "If set it controls if we should print out the 3rdparty source tree in the repo or not.").orFalse
 
-    (repoRoot |@| depsFile |@| resolvedOutput |@| shaFile |@| targetFile |@| buildifier |@| pomFile |@| checkOnly |@| Verbosity.opt |@| disable3rdPartyInRepos).map(Generate(_, _, _, _, _, _, _, _, _, _))
+    (repoRoot |@| depsFile |@| resolvedOutput |@| shaFile.orNone |@| targetFile |@| buildifier |@| pomFile |@| Verbosity.opt |@| disable3rdPartyInRepos)
+      .map(Generate(_, _, _, _, _, _, _, _, _))
+      .validate("at least one of pom-file, resolved-output or sha-file must be set") { g =>
+        g.shaFile.isDefined || g.resolvedOutput.isDefined || g.pomFile.isDefined  
+      }
+      .validate("if target-file is set, sha-file must be set") { g =>
+        g.targetFile.isEmpty || g.shaFile.isDefined
+      }
+      .orElse(
+        (repoRoot |@| depsFile |@| shaFile |@| buildifier |@| Verbosity.opt).map(CheckGen(_, _, _, _, _))
+      )
   }
 
   case class FormatDeps(deps: Path, overwrite: Boolean, verbosity: Verbosity)

--- a/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
@@ -15,7 +15,7 @@ object MakeDeps {
 
   private[this] val logger = LoggerFactory.getLogger("MakeDeps")
 
-  def apply(g: Command.Gen): Unit = {
+  def apply(g: Command.GenerateLike): Unit = {
 
     val content: String = Model.readFile(g.absDepsFile) match {
       case Success(str) => str

--- a/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
@@ -15,7 +15,7 @@ object MakeDeps {
 
   private[this] val logger = LoggerFactory.getLogger("MakeDeps")
 
-  def apply(g: Command.Generate): Unit = {
+  def apply(g: Command.Gen): Unit = {
 
     val content: String = Model.readFile(g.absDepsFile) match {
       case Success(str) => str
@@ -40,8 +40,6 @@ object MakeDeps {
         logger.error("resolution and sha collection failed", err)
         System.exit(1)
       case Success((normalized, shas, duplicates)) =>
-        // creates pom xml when path is provided
-        g.pomFile.foreach { fileName => CreatePom(normalized, fileName) }
         // build the BUILDs in thirdParty
         val targets = Writer.targets(normalized, model) match {
           case Right(t) => t
@@ -50,10 +48,7 @@ object MakeDeps {
             System.exit(-1)
             sys.error("exited already")
         }
-        val workspacePath = g.shaFilePath
-        val targetFilePathOpt = g.targetFile
         val projectRoot = g.repoRoot.toFile
-        val enable3rdPartyInRepo = g.enable3rdPartyInRepo
         val formatter: Writer.BuildFileFormatter = g.buildifier match {
           // If buildifier is provided, run it with the unformatted contents on its stdin; it will print the formatted
           // result on stdout.
@@ -93,21 +88,14 @@ object MakeDeps {
 
         // build the workspace
         val ws = Writer.workspace(g.depsFile, normalized, duplicates, shas, model)
-        if (g.checkOnly) {
-          workspacePath match {
-            case None =>
-              logger.error("check-only requires sha-file to be set, but it was not")
-              System.exit(-1)
-            case Some(path) =>
-              // TODO we shouldn't allow you to pass options we ignore, that's the whole point of
-              // a validating CLI option parser
-              executeCheckOnly(model, projectRoot, IO.path(path), ws, targets, formatter)
-          }
-        } else {
-          // TODO it is possible to pass None for both targetFilePathOpt and workspacePath and then nothing will happen and it will be confusing
-          // we should require you to generate one or both, not neither
-          executeGenerate(model, projectRoot, workspacePath.map(IO.path(_)), targetFilePathOpt.map(e => IO.path(e)), enable3rdPartyInRepo, ws, targets, formatter, g.resolvedOutput.map(IO.path),
-            artifacts)
+        g match {
+          case check: Command.CheckGen =>
+            executeCheckOnly(model, projectRoot, IO.path(check.shaFilePath), ws, targets, formatter)
+          case g: Command.Generate =>
+            // creates pom xml when path is provided
+            g.pomFile.foreach { fileName => CreatePom(normalized, fileName) }
+            executeGenerate(model, projectRoot, g.shaFilePath.map(IO.path(_)), g.targetFile.map(IO.path(_)), g.enable3rdPartyInRepo, ws, targets, formatter, g.resolvedOutput.map(IO.path),
+              artifacts)
         }
     }
   }
@@ -259,7 +247,13 @@ object MakeDeps {
   case class AllArtifacts(artifacts: List[ArtifactEntry])
 
 
-  private def executeCheckOnly(model: Model, projectRoot: File, workspacePath: IO.Path, workspaceContents: String, targets: List[Target], formatter: Writer.BuildFileFormatter): Unit = {
+  private def executeCheckOnly(
+      model: Model,
+      projectRoot: File,
+      workspacePath: IO.Path, 
+      workspaceContents: String,
+      targets: List[Target],
+      formatter: Writer.BuildFileFormatter): Unit = {
     // Build up the IO operations that need to run.
     val io = for {
       wsOK <- IO.compare(workspacePath, workspaceContents)

--- a/src/scala/com/github/johnynek/bazel_deps/ParseProject.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/ParseProject.scala
@@ -13,7 +13,7 @@ object ParseProject {
         val level = command.verbosity.repr.toUpperCase
         System.setProperty(DEFAULT_LOG_LEVEL_KEY, level)
         command match {
-          case gen: Command.Gen =>
+          case gen: Command.GenerateLike =>
             MakeDeps(gen)
           case gen: Command.FormatDeps =>
             FormatDeps(gen.deps.toFile, gen.overwrite)

--- a/src/scala/com/github/johnynek/bazel_deps/ParseProject.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/ParseProject.scala
@@ -13,7 +13,7 @@ object ParseProject {
         val level = command.verbosity.repr.toUpperCase
         System.setProperty(DEFAULT_LOG_LEVEL_KEY, level)
         command match {
-          case gen: Command.Generate =>
+          case gen: Command.Gen =>
             MakeDeps(gen)
           case gen: Command.FormatDeps =>
             FormatDeps(gen.deps.toFile, gen.overwrite)

--- a/src/scala/com/github/johnynek/bazel_deps/Writer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Writer.scala
@@ -115,6 +115,7 @@ object Writer {
         IO.compare(bf, data(bf))
     }
   }
+
   def createBuildFilesAndTargetFile(buildHeader: String, ts: List[Target], targetFileOpt: Option[IO.Path], enable3rdPartyInRepo: Boolean, thirdPartyDirectory: DirectoryName, formatter: BuildFileFormatter, buildFileName: String): Result[Int] = {
     val with3rdpartyPrinted = if (enable3rdPartyInRepo) {
       createBuildFiles(buildHeader, ts, formatter, buildFileName)


### PR DESCRIPTION
We have developed a `check-only` option which only checks.

Unfortunately, it ignores many options and doesn't actually check everything. I think this is because the people who added the `check-only` only cared about certain options.

This will break people who are passing options to check-only that are currently ignored, but it may save people who thing more things are being checked than are.

A better solution is to have a check mode for everything, which instead of writing a file, makes sure that the file already exists and has been written. This could possibly be done with the IO abstraction we have already. In that mode, `rm` would do nothing, read would work as normal, but write would just fail unless we are writing the exact same file (maybe with some decent reporting of differences).

poor person's CI
```
oboykin@Oscars-MacBook-Pro bazel-deps % git rev-parse HEAD
c0fd4a17adeb2f978b88a045828c1d029b827d95
oboykin@Oscars-MacBook-Pro bazel-deps % ./bazel build //...
INFO: Analyzed 102 targets (0 packages loaded, 0 targets configured).
INFO: Found 102 targets...
INFO: Elapsed time: 0.075s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
oboykin@Oscars-MacBook-Pro bazel-deps % ./bazel test //... 
INFO: Analyzed 102 targets (0 packages loaded, 0 targets configured).
INFO: Found 94 targets and 8 test targets...
INFO: Elapsed time: 0.073s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
//test/scala/com/github/johnynek/bazel_deps:coursier_test       (cached) PASSED in 16.3s
//test/scala/com/github/johnynek/bazel_deps:createpomtest       (cached) PASSED in 8.5s
//test/scala/com/github/johnynek/bazel_deps:graphtest           (cached) PASSED in 5.9s
//test/scala/com/github/johnynek/bazel_deps:modeltest           (cached) PASSED in 6.0s
//test/scala/com/github/johnynek/bazel_deps:normalizertest      (cached) PASSED in 6.1s
//test/scala/com/github/johnynek/bazel_deps:parsegenerateddoctest (cached) PASSED in 33.6s
//test/scala/com/github/johnynek/bazel_deps:parsetest           (cached) PASSED in 6.0s
//test/scala/com/github/johnynek/bazel_deps:parsetestcases      (cached) PASSED in 5.8s

Executed 0 out of 8 tests: 8 tests pass.
INFO: Build completed successfully, 1 total action
```