### PR TITLE
Rename IO to FS since it is about filesystem abstraction

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/BUILD
+++ b/src/scala/com/github/johnynek/bazel_deps/BUILD
@@ -149,8 +149,8 @@ scala_library(
 )
 
 scala_library(
-    name = "io",
-    srcs = ["IO.scala"],
+    name = "fs",
+    srcs = ["FS.scala"],
     visibility = ["//visibility:public"],
     exports = [
         "//3rdparty/jvm/org/typelevel:cats_free",
@@ -185,7 +185,7 @@ scala_library(
     deps = [
         ":depsmodel",
         ":graph",
-        ":io",
+        ":fs",
         "//3rdparty/jvm/io/circe:circe_core",
         "//3rdparty/jvm/io/circe:circe_generic",
         "//3rdparty/jvm/org/slf4j:slf4j_api",
@@ -213,7 +213,7 @@ scala_library(
         ":depsmodel",
         ":gradle_resolver",
         ":graph",
-        ":io",
+        ":fs",
         ":normalizer",
         ":resolver",
         ":writer",
@@ -281,7 +281,7 @@ scala_library(
     deps = [
         ":depsmodel",
         ":graph",
-        ":io",
+        ":fs",
         "//3rdparty/jvm/org/scala_lang/modules:scala_xml",
     ],
 )

--- a/src/scala/com/github/johnynek/bazel_deps/CreatePom.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/CreatePom.scala
@@ -30,8 +30,8 @@ object CreatePom {
     p.format(pomXml)
   }
 
-  def writeIO(dependencies: Graph[MavenCoordinate, Unit], path: IO.Path): IO.Result[Unit] =
-    IO.writeUtf8(path, translate(dependencies))
+  def writeIO(dependencies: Graph[MavenCoordinate, Unit], path: FS.Path): FS.Result[Unit] =
+    FS.writeUtf8(path, translate(dependencies))
 
   def apply(dependencies: Graph[MavenCoordinate, Unit], path: String): Unit = {
     scala.xml.XML.save(

--- a/src/scala/com/github/johnynek/bazel_deps/FS.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/FS.scala
@@ -15,11 +15,11 @@ import scala.util.control.NonFatal
 
 import cats.implicits._
 
-/** To enable mocking and testing, we keep IO abstract and then plug in
+/** To enable mocking and testing, we keep file system actions abstract and then plug in
   * implementations
   */
 
-object IO {
+object FS {
   private[this] val logger = LoggerFactory.getLogger("IO")
 
   val charset = "UTF-8"
@@ -104,7 +104,7 @@ object IO {
   def orUnit(optIO: Option[Result[Unit]]): Result[Unit] =
     optIO match {
       case Some(io) => io
-      case None => IO.const(())
+      case None => const(())
     }
 
   def fileSystemExec(root: JPath): FunctionK[Ops, Try] =
@@ -207,12 +207,12 @@ object IO {
   }
 
   sealed abstract class CheckException(val message: String) extends Exception(message) {
-    def path: IO.Path
+    def path: Path
   }
 
   object CheckException {
-    case class DirectoryMissing(path: IO.Path) extends CheckException(s"directory ${path.asString} expected but missing")
-    case class WriteMismatch(path: IO.Path, current: Option[String], expected: String, compressed: Boolean) extends CheckException(
+    case class DirectoryMissing(path: Path) extends CheckException(s"directory ${path.asString} expected but missing")
+    case class WriteMismatch(path: Path, current: Option[String], expected: String, compressed: Boolean) extends CheckException(
       (if (compressed) "compressed " else "") + s"file ${path.asString} does not " + (if (current.isEmpty) "exist." else "match.")
     )
   }

--- a/src/scala/com/github/johnynek/bazel_deps/Label.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Label.scala
@@ -1,6 +1,6 @@
 package com.github.johnynek.bazel_deps
 
-import IO.Path
+import FS.Path
 
 case class Label(workspace: Option[String], path: Path, name: String) {
   def packageLabel: Label = Label(workspace, path, "")

--- a/test/scala/com/github/johnynek/bazel_deps/BUILD
+++ b/test/scala/com/github/johnynek/bazel_deps/BUILD
@@ -31,7 +31,7 @@ scala_library(name = "writergen",
            srcs = ["WriterGenerators.scala"],
            deps = ["//src/scala/com/github/johnynek/bazel_deps:depsmodel",
                    "//src/scala/com/github/johnynek/bazel_deps:writer",
-                   "//src/scala/com/github/johnynek/bazel_deps:io",
+                   "//src/scala/com/github/johnynek/bazel_deps:fs",
                    "//3rdparty/jvm/org/typelevel:paiges_core",
                    "//3rdparty/jvm/org/scalacheck",
                    ":modelgen"])

--- a/test/scala/com/github/johnynek/bazel_deps/WriterGenerators.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/WriterGenerators.scala
@@ -7,7 +7,7 @@ object WriterGenerators {
 
   val labelGen: Gen[Label] = for {
     workspace <- Gen.option(Gen.identifier)
-    path <- Gen.listOf(Gen.identifier).map { l => IO.Path(l) }
+    path <- Gen.listOf(Gen.identifier).map { l => FS.Path(l) }
     name <- Gen.identifier
   } yield Label(workspace, path, name)
 


### PR DESCRIPTION
This code is actually about file system abstraction, and not general modeling of side effects. It was written quite some time ago (2016 I think). That was before cats-effect was mature.

Now, cats-effect is one of the crown jewels of the scala ecosystem, and we should use that to better communicate which methods are running side effects vs not. So to prepare for that, we should rename this file system abstraction FS instead of IO.

