### PR TITLE
Make gradle lock files relative to the repo root

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/GradleResolver.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/GradleResolver.scala
@@ -3,13 +3,14 @@ package com.github.johnynek.bazel_deps
 import cats.MonadError
 import cats.data.{Validated, ValidatedNel}
 import io.circe.jawn.JawnParser
-import java.nio.file.Paths
+import java.nio.file.{Path, Paths}
 import scala.collection.immutable.SortedMap
 import scala.util.{Failure, Success, Try}
 
 import cats.implicits._
 
 class GradleResolver(
+    rootPath: Path,
     versionConflictPolicy: VersionConflictPolicy,
     gradleTpe: ResolverType.Gradle,
     getShasFn: List[MavenCoordinate] => Try[SortedMap[MavenCoordinate, ResolvedShasValue]]
@@ -28,7 +29,7 @@ class GradleResolver(
   private def loadLockFile(
       lockFile: String
   ): Try[GradleLockFile] =
-    (Model.readFile(Paths.get(lockFile)) match {
+    (Model.readFile(rootPath.resolve(lockFile)) match {
       case Success(str) => Success(str)
       case Failure(err) =>
         Failure(new Exception(s"Failed to read ${lockFile}", err))

--- a/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
@@ -34,7 +34,7 @@ object MakeDeps {
     }
     val projectRoot = g.repoRoot
 
-    resolverCachePath(model, projectRoot).flatMap(runResolve(model, _)) match {
+    resolverCachePath(model, projectRoot).flatMap(runResolve(projectRoot, model, _)) match {
       case Failure(err) =>
         logger.error("resolution and sha collection failed", err)
         System.exit(1)
@@ -150,6 +150,7 @@ object MakeDeps {
       .map(_.toAbsolutePath)
 
   private[bazel_deps] def runResolve(
+      rootPath: Path,
       model: Model,
       resolverCachePath: Path
   ): Try[
@@ -182,6 +183,7 @@ object MakeDeps {
           new CoursierResolver(model.getOptions.getResolvers, ec, 3600.seconds, resolverCachePath)
 
         val resolver = new GradleResolver(
+            rootPath,
             model.getOptions.getVersionConflictPolicy,
             g,
             { ls => coursierResolver.run(coursierResolver.getShas(ls)) })

--- a/test/scala/com/github/johnynek/bazel_deps/CoursierTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/CoursierTest.scala
@@ -1,6 +1,6 @@
 package com.github.johnynek.bazel_deps
 
-import java.nio.file.Files
+import java.nio.file.{ Files, Paths }
 import org.scalatest.FunSuite
 
 class CoursierTest extends FunSuite  {
@@ -36,7 +36,7 @@ dependencies:
 """
 
     val model = Decoders.decodeModel(Yaml, config).right.get
-    val (graph, shas, normalized) = MakeDeps.runResolve(model, tmpPath).get
+    val (graph, shas, normalized) = MakeDeps.runResolve(Paths.get("/"), model, tmpPath).get
     normalized.keys.foreach { uvc =>
       assert(!uvc.asString.contains("bouncycastle"))
     }
@@ -63,7 +63,7 @@ dependencies:
 """
 
     val model = Decoders.decodeModel(Yaml, config).right.get
-    val (graph, shas, normalized) = MakeDeps.runResolve(model, tmpPath).get
+    val (graph, shas, normalized) = MakeDeps.runResolve(Paths.get("/"), model, tmpPath).get
     assert(graph.nodes.contains(
       MavenCoordinate(
         MavenGroup("net.sf.json-lib"), MavenArtifactId("json-lib", "jar", "jdk15"), Version("2.4"))))
@@ -90,7 +90,7 @@ dependencies:
 """
 
     val model = Decoders.decodeModel(Yaml, config).right.get
-    val (graph, shas, normalized) = MakeDeps.runResolve(model, tmpPath).get
+    val (graph, shas, normalized) = MakeDeps.runResolve(Paths.get("/"), model, tmpPath).get
     // org.sonatype.sisu:sisu-guice:no_aop is a transitive dependency of org.sonatype.sisu:sisu-inject-bean
     assert(graph.nodes.contains(
       MavenCoordinate(
@@ -119,7 +119,7 @@ dependencies:
 """
 
     val model = Decoders.decodeModel(Yaml, config).right.get
-    val (graph, shas, normalized) = MakeDeps.runResolve(model, tmpPath).get
+    val (graph, shas, normalized) = MakeDeps.runResolve(Paths.get("/"), model, tmpPath).get
 
     assert(graph.nodes.contains(
       MavenCoordinate(
@@ -156,7 +156,7 @@ dependencies:
 """
 
     val model = Decoders.decodeModel(Yaml, config).right.get
-    val (graph, shas, normalized) = MakeDeps.runResolve(model, tmpPath).get
+    val (graph, shas, normalized) = MakeDeps.runResolve(Paths.get("/"), model, tmpPath).get
     // org.sonatype.sisu:sisu-guice:no_aop is a transitive dependency of org.sonatype.sisu:sisu-inject-bean
     // we exclude it for this test
     assert(!graph.nodes.contains(
@@ -183,7 +183,7 @@ dependencies:
 """
 
     val model = Decoders.decodeModel(Yaml, config).right.get
-    val (graph, shas, normalized) = MakeDeps.runResolve(model, tmpPath).get
+    val (graph, shas, normalized) = MakeDeps.runResolve(Paths.get("/"), model, tmpPath).get
 
     assert(graph.nodes.contains(
       MavenCoordinate(

--- a/test/scala/com/github/johnynek/bazel_deps/CreatePomTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/CreatePomTest.scala
@@ -2,7 +2,7 @@ package com.github.johnynek.bazel_deps
 
 import org.scalatest.FunSuite
 
-import java.nio.file.Files
+import java.nio.file.{ Files, Paths }
 
 class CreatePomTest extends FunSuite{
 
@@ -59,7 +59,7 @@ dependencies:
       val model = Decoders.decodeModel(Yaml, dependenciesYaml).right.get
       val tmpPath = Files.createTempDirectory("cache")
       tmpPath.toFile.deleteOnExit()
-      val (dependencies, _, _) = MakeDeps.runResolve(model, tmpPath).get
+      val (dependencies, _, _) = MakeDeps.runResolve(Paths.get("/"), model, tmpPath).get
       val p = new scala.xml.PrettyPrinter(80, 2)
 
     assert(CreatePom.translate(dependencies) == p.format(expectedPomXml))


### PR DESCRIPTION
we never exercised a branch where the pwd wasn't already the repo-root, so we didn't see that it wouldn't work otherwise.

If you use a bazel run, the pwd in that case is the path to the binary so it will fail if you try to use bazel run with gradle.