### PR TITLE
CreatePom parsing update with maven type and classifier tags

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/CreatePom.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/CreatePom.scala
@@ -5,14 +5,23 @@ object CreatePom {
   implicit class MavenCoordinateExtension(private val self: MavenCoordinate)
       extends AnyVal {
     def toXml: Elem = {
-      <dependency>
-        <groupId>{self.group.asString}</groupId>
-        <artifactId>{self.artifact.artifactId}</artifactId>
-        <type>{self.artifact.packaging}</type>
-        <classifier>{self.artifact.classifier}</classifier>
-        <version>{self.version.asString}</version>
-      </dependency>
+      if (self.artifact.classifier==None) {
+        <dependency>
+          <groupId>{self.group.asString}</groupId>
+          <artifactId>{self.artifact.asString.split(":")(0)}</artifactId>
+          <type>{self.artifact.packaging}</type>
+          <version>{self.version.asString}</version>
+        </dependency>
+      } else {
+        <dependency>
+          <groupId>{self.group.asString}</groupId>
+          <artifactId>{self.artifact.asString.split(":")(0)}</artifactId>
+          <type>{self.artifact.packaging}</type>
+          <classifier>{self.artifact.classifier}</classifier>
+          <version>{self.version.asString}</version>
+        </dependency>
     }
+  }
   }
 
   def translate(dependencies: Graph[MavenCoordinate, Unit]): String = {

--- a/src/scala/com/github/johnynek/bazel_deps/CreatePom.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/CreatePom.scala
@@ -17,7 +17,7 @@ object CreatePom {
           <groupId>{self.group.asString}</groupId>
           <artifactId>{self.artifact.artifactId}</artifactId>
           <type>{self.artifact.packaging}</type>
-          <classifier>{self.artifact.classifier}</classifier>
+          <classifier>{self.artifact.classifier.getOrElse(None)}</classifier>
           <version>{self.version.asString}</version>
         </dependency>
     }

--- a/src/scala/com/github/johnynek/bazel_deps/CreatePom.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/CreatePom.scala
@@ -7,7 +7,7 @@ object CreatePom {
     def toXml: Elem = {
       <dependency>
         <groupId>{self.group.asString}</groupId>
-        <artifactId>{self.artifact.asString.split(":")(0)}</artifactId>
+        <artifactId>{self.artifact.artifactId}</artifactId>
         <type>{self.artifact.packaging}</type>
         <classifier>{self.artifact.classifier}</classifier>
         <version>{self.version.asString}</version>

--- a/src/scala/com/github/johnynek/bazel_deps/CreatePom.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/CreatePom.scala
@@ -8,14 +8,14 @@ object CreatePom {
       if (self.artifact.classifier==None) {
         <dependency>
           <groupId>{self.group.asString}</groupId>
-          <artifactId>{self.artifact.asString.split(":")(0)}</artifactId>
+          <artifactId>{self.artifact.artifactId}</artifactId>
           <type>{self.artifact.packaging}</type>
           <version>{self.version.asString}</version>
         </dependency>
       } else {
         <dependency>
           <groupId>{self.group.asString}</groupId>
-          <artifactId>{self.artifact.asString.split(":")(0)}</artifactId>
+          <artifactId>{self.artifact.artifactId}</artifactId>
           <type>{self.artifact.packaging}</type>
           <classifier>{self.artifact.classifier}</classifier>
           <version>{self.version.asString}</version>

--- a/src/scala/com/github/johnynek/bazel_deps/CreatePom.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/CreatePom.scala
@@ -7,7 +7,9 @@ object CreatePom {
     def toXml: Elem = {
       <dependency>
         <groupId>{self.group.asString}</groupId>
-        <artifactId>{self.artifact.asString}</artifactId>
+        <artifactId>{self.artifact.asString.split(":")(0)}</artifactId>
+        <type>{self.artifact.packaging}</type>
+        <classifier>{self.artifact.classifier}</classifier>
         <version>{self.version.asString}</version>
       </dependency>
     }

--- a/test/scala/com/github/johnynek/bazel_deps/CreatePomTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/CreatePomTest.scala
@@ -32,8 +32,9 @@ dependencies:
     flying-saucer-pdf:
       lang: java
       version: "9.0.3"
-  netty:
-    version: "4.1.85.Final"
+  io.netty:
+    netty:
+      version: "4.1.85.Final"
       lang: java
       modules: [resolver-dns]
 """

--- a/test/scala/com/github/johnynek/bazel_deps/CreatePomTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/CreatePomTest.scala
@@ -78,7 +78,7 @@ dependencies:
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver-dns-native-macos</artifactId>
             <type>jar</type>
-            <classifier>osx-86_64</classifier>
+            <classifier>osx-x86_64</classifier>
             <version>4.1.85.Final</version>
           </dependency>
         </dependencies>

--- a/test/scala/com/github/johnynek/bazel_deps/CreatePomTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/CreatePomTest.scala
@@ -32,11 +32,6 @@ dependencies:
     flying-saucer-pdf:
       lang: java
       version: "9.0.3"
-  io.netty:
-    netty:
-      version: "4.1.85.Final"
-      lang: java
-      modules: [resolver-dns]
 """
 
     val expectedPomXml =
@@ -46,41 +41,20 @@ dependencies:
           <dependency>
             <groupId>com.lowagie</groupId>
             <artifactId>itext</artifactId>
+            <type>jar</type>
             <version>2.1.7</version>
           </dependency>
           <dependency>
             <groupId>org.xhtmlrenderer</groupId>
             <artifactId>flying-saucer-core</artifactId>
+            <type>jar</type>
             <version>9.0.3</version>
           </dependency>
           <dependency>
             <groupId>org.xhtmlrenderer</groupId>
             <artifactId>flying-saucer-pdf</artifactId>
+            <type>jar</type>
             <version>9.0.3</version>
-          </dependency>
-          <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-resolver-dns</artifactId>
-            <version>4.1.85.Final</version>
-          </dependency>
-          <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-resolver-dns-classes-macos</artifactId>
-            <version>4.1.85.Final</version>
-          </dependency>
-          <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-resolver-dns-native-macos</artifactId>
-            <type>jar</type>
-            <classifier>osx-aarch_64</classifier>
-            <version>4.1.85.Final</version>
-          </dependency>
-          <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-resolver-dns-native-macos</artifactId>
-            <type>jar</type>
-            <classifier>osx-x86_64</classifier>
-            <version>4.1.85.Final</version>
           </dependency>
         </dependencies>
       </project>

--- a/test/scala/com/github/johnynek/bazel_deps/CreatePomTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/CreatePomTest.scala
@@ -32,6 +32,10 @@ dependencies:
     flying-saucer-pdf:
       lang: java
       version: "9.0.3"
+  netty:
+    version: "4.1.85.Final"
+      lang: java
+      modules: [resolver-dns]
 """
 
     val expectedPomXml =
@@ -52,6 +56,30 @@ dependencies:
             <groupId>org.xhtmlrenderer</groupId>
             <artifactId>flying-saucer-pdf</artifactId>
             <version>9.0.3</version>
+          </dependency>
+          <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns</artifactId>
+            <version>4.1.85.Final</version>
+          </dependency>
+          <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns-classes-macos</artifactId>
+            <version>4.1.85.Final</version>
+          </dependency>
+          <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns-native-macos</artifactId>
+            <type>jar</type>
+            <classifier>osx-aarch_64</classifier>
+            <version>4.1.85.Final</version>
+          </dependency>
+          <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns-native-macos</artifactId>
+            <type>jar</type>
+            <classifier>osx-86_64</classifier>
+            <version>4.1.85.Final</version>
           </dependency>
         </dependencies>
       </project>

--- a/test/scala/com/github/johnynek/bazel_deps/CreatePomTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/CreatePomTest.scala
@@ -16,8 +16,13 @@ options:
     - id: "mavencentral"
       type: "default"
       url: https://repo.maven.apache.org/maven2/
+    - id: "mavenother"
+      type: "default"
+      url: https://repo1.maven.apache.org/maven2/
   transitivity: runtime_deps
   versionConflictPolicy: highest
+  strictVisibility: true
+ 
 
 dependencies:
   com.lowagie:
@@ -32,6 +37,10 @@ dependencies:
     flying-saucer-pdf:
       lang: java
       version: "9.0.3"
+  io.netty:
+    netty-resolver-dns-native-macos:jar:osx-x86_64:
+      lang: java
+      version: "4.1.85.Final"
 """
 
     val expectedPomXml =
@@ -43,6 +52,73 @@ dependencies:
             <artifactId>itext</artifactId>
             <type>jar</type>
             <version>2.1.7</version>
+          </dependency>
+          <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+            <type>jar</type>
+            <version>4.1.85.Final</version>
+          </dependency>
+          <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+            <type>jar</type>
+            <version>4.1.85.Final</version>
+          </dependency>
+          <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-dns</artifactId>
+            <type>jar</type>
+            <version>4.1.85.Final</version>
+          </dependency>
+          <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+            <type>jar</type>
+            <version>4.1.85.Final</version>
+          </dependency>
+          <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <type>jar</type>
+            <version>4.1.85.Final</version>
+          </dependency>
+          <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver</artifactId>
+            <type>jar</type>
+            <version>4.1.85.Final</version>
+          </dependency>
+          <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns</artifactId>
+            <type>jar</type>
+            <version>4.1.85.Final</version>
+          </dependency>
+          <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns-classes-macos</artifactId>
+            <type>jar</type>
+            <version>4.1.85.Final</version>
+          </dependency>
+          <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns-native-macos</artifactId>
+            <type>jar</type>
+            <classifier>osx-x86_64</classifier>
+            <version>4.1.85.Final</version>
+          </dependency>
+          <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+            <type>jar</type>
+            <version>4.1.85.Final</version>
+          </dependency>
+          <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-unix-common</artifactId>
+            <type>jar</type>
+            <version>4.1.85.Final</version>
           </dependency>
           <dependency>
             <groupId>org.xhtmlrenderer</groupId>
@@ -64,7 +140,6 @@ dependencies:
       tmpPath.toFile.deleteOnExit()
       val (dependencies, _, _) = MakeDeps.runResolve(Paths.get("/"), model, tmpPath).get
       val p = new scala.xml.PrettyPrinter(80, 2)
-
     assert(CreatePom.translate(dependencies) == p.format(expectedPomXml))
   }
 }


### PR DESCRIPTION
I left the MavenArtifactId class untouched to just fix this in CreatePom and avoid breaking other things that depend on that class. I wasn't able to get bazel to run tests for me(even on master), but confirmed that mvn was able to handle the classifier and type tags using the same format as what's in the updated CreatePomTest! 