### PR TITLE
add explicit bundles for native-build

### DIFF
--- a/ci_scripts/make_native_artifact.sh
+++ b/ci_scripts/make_native_artifact.sh
@@ -16,6 +16,7 @@ mkdir templates/
 cp ../src/scala/com/github/johnynek/bazel_deps/templates/* templates/
 cp ../bazel-deps.jar .
 cp ../ci_scripts/reflection.json .
+cp ../ci_scripts/resource-config.json .
 
 native-image -H:+ReportUnsupportedElementsAtRuntime \
  --initialize-at-build-time \
@@ -26,6 +27,7 @@ native-image -H:+ReportUnsupportedElementsAtRuntime \
  -H:EnableURLProtocols=http,https \
  --enable-all-security-services \
  -H:ReflectionConfigurationFiles=reflection.json \
+ -H:ResourceConfigurationFiles=resource-config.json \
  --allow-incomplete-classpath \
  -H:+ReportExceptionStackTraces \
  --no-fallback \

--- a/ci_scripts/resource-config.json
+++ b/ci_scripts/resource-config.json
@@ -1,0 +1,6 @@
+{
+    "resources": [],
+    "bundles": [
+        {"name":"com.sun.org.apache.xerces.internal.impl.msg.XMLMessages"}
+    ]
+}


### PR DESCRIPTION
Getting sometimes weird runtime errors from Graal bundle:
```
Could not load any resource bundle by com.sun.org.apache.xerces.internal.impl.msg.XMLMessages
```

Inspired by https://dplatz.de/blog/2020/quarkus-graalvm-reflection.html

