### PR TITLE
Improve logging for gradle resolver

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/GradleLockFile.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/GradleLockFile.scala
@@ -48,7 +48,7 @@ object GradleLockFile {
           left.testRuntimeClasspath,
           right.testRuntimeClasspath
         )
-      } yield {
+      } yield
         GradleLockFile(
           annotationProcessor,
           compileClasspath,
@@ -57,9 +57,9 @@ object GradleLockFile {
           testCompileClasspath,
           testRuntimeClasspath
         )
-      }
     }
   }
+
   def empty = GradleLockFile(None, None, None, None, None, None)
 
   def decodeGradleLockFile(


### PR DESCRIPTION
This does two main things:

1. removes an annoying println in our logs about using VersionResolver. We have configured to use the "highest" conflict resolution. We don't need to println every time that runs. If we want to error, there is a VersionConflictPolicy for that: Fixed. I moved that println to a debug setting (which we can select with `--verbosity debug` to bazel-deps).
2. adds a bit more info logging to make sure deleted edges were being seen. 