### PR TITLE
Improve resolution comment

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/GradleResolver.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/GradleResolver.scala
@@ -336,7 +336,7 @@ private def cleanUpMap(
     (
         Graph[MavenCoordinate, Unit],
         SortedMap[MavenCoordinate, ResolvedShasValue],
-        Map[UnversionedCoordinate, Set[Edge[MavenCoordinate, Unit]]]
+        Map[UnversionedCoordinate, Set[Edge[MavenCoordinate, Boolean]]]
     )
   ] = {
     def replaced(m: MavenCoordinate): Boolean =

--- a/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
@@ -182,7 +182,7 @@ object MakeDeps {
     (
         Graph[MavenCoordinate, Unit],
         SortedMap[MavenCoordinate, ResolvedShasValue],
-        Map[UnversionedCoordinate, Set[Edge[MavenCoordinate, Unit]]]
+        Map[UnversionedCoordinate, Set[Edge[MavenCoordinate, Boolean]]]
     )
   ] =
     model.getOptions.getResolverType match {
@@ -259,7 +259,8 @@ object MakeDeps {
                 ns.flatMap { n =>
                   graph
                     .hasDestination(n)
-                    .filter(e => normalized.nodes(e.source))
+                    // label means whether it is evicted or not
+                    .map(e => e.copy(label = !normalized.nodes(e.source)))
                 }
               }
               .filter { case (_, set) =>

--- a/src/scala/com/github/johnynek/bazel_deps/Resolver.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Resolver.scala
@@ -17,7 +17,7 @@ object Resolver {
   type Result = (
       Graph[MavenCoordinate, Unit],
       SortedMap[MavenCoordinate, ResolvedShasValue],
-      Map[UnversionedCoordinate, Set[Edge[MavenCoordinate, Unit]]]
+      Map[UnversionedCoordinate, Set[Edge[MavenCoordinate, Boolean]]]
   )
 }
 

--- a/src/scala/com/github/johnynek/bazel_deps/Writer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Writer.scala
@@ -210,7 +210,7 @@ object Writer {
   }
 
   def workspace(depsFile: String, g: Graph[MavenCoordinate, Unit],
-                duplicates: Map[UnversionedCoordinate, Set[Edge[MavenCoordinate, Unit]]],
+                duplicates: Map[UnversionedCoordinate, Set[Edge[MavenCoordinate, Boolean]]],
                 shas: Map[MavenCoordinate, ResolvedShasValue],
                 model: Model): String = {
     val nodes = g.nodes
@@ -334,7 +334,7 @@ object Writer {
   private def concreteToArtifactEntry(
       coord: MavenCoordinate,
       g: Graph[MavenCoordinate, Unit],
-      duplicates: Map[UnversionedCoordinate, Set[Edge[MavenCoordinate, Unit]]],
+      duplicates: Map[UnversionedCoordinate, Set[Edge[MavenCoordinate, Boolean]]],
       shas: Map[MavenCoordinate, ResolvedShasValue],
       model: Model
   ): ArtifactEntry = {
@@ -376,7 +376,8 @@ object Writer {
       s"""# duplicates in ${coord.unversioned.asString} $status\n""" +
         vs.filterNot(e => replaced(e.source))
           .map { e =>
-            s"""# - ${e.source.asString} wanted version ${e.destination.version.asString}\n"""
+            val evicted = if (e.label) " (evicted)" else ""
+            s"""# - ${e.source.asString}${evicted} wanted version ${e.destination.version.asString}\n"""
           }
           .toSeq
           .sorted
@@ -405,7 +406,7 @@ object Writer {
 
   def artifactEntries(
       g: Graph[MavenCoordinate, Unit],
-      duplicates: Map[UnversionedCoordinate, Set[Edge[MavenCoordinate, Unit]]],
+      duplicates: Map[UnversionedCoordinate, Set[Edge[MavenCoordinate, Boolean]]],
       shas: Map[MavenCoordinate, ResolvedShasValue],
       model: Model
   ): Either[NonEmptyList[TargetsError], List[ArtifactEntry]] = {


### PR DESCRIPTION
See #379. This changes the current resolution comment from:

```
# duplicates in org.threeten:threetenbp downgraded to 1.6.8
# - com.google.cloud:google-cloud-pubsub:1.123.0 wanted version 1.6.5
# - com.google.cloud:google-cloud-storage:2.14.0 wanted version 1.6.3
```

to:

```
# duplicates in org.threeten:threetenbp promoted to 1.6.8
# - com.google.cloud:google-cloud-pubsub:1.123.0 wanted version 1.6.5
# - com.google.cloud:google-cloud-storage:2.14.0 wanted version 1.6.3
# - com.google.cloud:google-cloud-storage:2.27.0 (evicted) wanted version 1.6.8
```