### PR TITLE
Add hashInHttpHeaders option for Coursier resolver

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/BUILD.bazel
+++ b/src/scala/com/github/johnynek/bazel_deps/BUILD.bazel
@@ -85,6 +85,8 @@ scala_library(
         ":graph",
         ":resolver",
         ":settings_loader",
+        "//3rdparty/jvm/io/circe:circe_core",
+        "//3rdparty/jvm/io/circe:circe_jawn",
         "//3rdparty/jvm/io/get_coursier:coursier",
         "//3rdparty/jvm/io/get_coursier:coursier_cache",
         "//3rdparty/jvm/io/get_coursier:coursier_core",

--- a/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
@@ -193,19 +193,19 @@ object MakeDeps {
             model.getOptions.getResolvers.collect { case e: MavenServer => e },
             resolverCachePath)
         )
-      case ResolverType.Coursier =>
+      case c: ResolverType.Coursier =>
         val ec = scala.concurrent.ExecutionContext.Implicits.global
         import scala.concurrent.duration._
         resolve(
           model,
-          new CoursierResolver(model.getOptions.getResolvers, ec, 3600.seconds, resolverCachePath)
+          new CoursierResolver(model.getOptions.getResolvers, c.getHashInHttpHeaders, ec, 3600.seconds, resolverCachePath)
         )
       case g: ResolverType.Gradle =>
         val ec = scala.concurrent.ExecutionContext.Implicits.global
         import scala.concurrent.duration._
 
         lazy val coursierResolver =
-          new CoursierResolver(model.getOptions.getResolvers, ec, 3600.seconds, resolverCachePath)
+          new CoursierResolver(model.getOptions.getResolvers, false, ec, 3600.seconds, resolverCachePath)
 
         val resolver = new GradleResolver(
             rootPath,


### PR DESCRIPTION
Add a new resolver option `hashInHttpHeaders` for Coursier, which tells bazel-deps to use [checksums in HTTP headers](https://maven.apache.org/resolver/expected-checksums.html#non-standard-x-headers) if possible, instead of downloading the jar artifact and computing hash digests locally. The option is read from the `resolverOptions` object in the input YAML file.

If this option is true, when computing checksums, bazel-deps will:

1. First try to make a `HEAD` request to the artifact.
2. If the `HEAD` request was successful:
    1. Save the headers as a JSON file in the Coursier cache directory
    2. If the headers include the necessary checksum, return that.
    3. If the headers _don't_ contain the checksum, fall back to downloading the artifact itself.
3. If the `HEAD` request was unsuccessful:
    1. If the status code is 404, but the `.pom` file exists for this artifact, assume that the artifact will never be published in the future. Cache the error status in the Coursier cache directory to avoid downloading this file in the future. This is the same heuristic that [Coursier itself](https://github.com/coursier/coursier/blob/v2.0.0-RC4-1/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala#L86-L97) uses.
    3. Return error.

This change reduces the fully-cached runtime of bazel-deps on our internal repo (which uses Artifactory, which supplies both SHA-1 and SHA-256 hashes via headers) from 80s to 7s, and reduces the size of the Coursier cache directory by 99%.

Co-authored-by: Keith Lea <keithl@stripe.com>

cc @keithl-stripe