### PR TITLE
If authFile is missing, try to use the user's default .netrc file (~/.netrc)

### DIFF
--- a/3rdparty/workspace.bzl
+++ b/3rdparty/workspace.bzl
@@ -1,11 +1,22 @@
 # Do not edit. bazel-deps autogenerates this file from dependencies.yaml.
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_netrc", "read_user_netrc", "use_netrc")
+
+def _get_auth(ctx, urls):
+    netrc = {}
+    if 'netrc' in dir(ctx.attr):
+        netrc = read_netrc(ctx, ctx.attr.netrc)
+    else:
+        netrc = read_user_netrc(ctx)
+    return use_netrc(netrc, urls, {})
+
 def _jar_artifact_impl(ctx):
     jar_name = "%s.jar" % ctx.name
     ctx.download(
         output = ctx.path("jar/%s" % jar_name),
         url = ctx.attr.urls,
         sha256 = ctx.attr.sha256,
-        executable = False
+        executable = False,
+        auth = _get_auth(ctx, ctx.attr.urls)
     )
     src_name = "%s-sources.jar" % ctx.name
     srcjar_attr = ""
@@ -15,7 +26,8 @@ def _jar_artifact_impl(ctx):
             output = ctx.path("jar/%s" % src_name),
             url = ctx.attr.src_urls,
             sha256 = ctx.attr.src_sha256,
-            executable = False
+            executable = False,
+            auth = _get_auth(ctx, ctx.attr.src_urls)
         )
         srcjar_attr = '\n    srcjar = ":%s",' % src_name
 

--- a/src/scala/com/github/johnynek/bazel_deps/Writer.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/Writer.scala
@@ -283,38 +283,40 @@ object Writer {
       }
       .mkString("\n")
 
-    val ifAuth: String => String =
-      if (model.hasAuthFile) identity
-      else _ => ""
-
     val jarArtifactImpl =
-      s"""${
-        if (model.hasAuthFile)
-          s"""|load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_netrc", "use_netrc")
-              |
-              |def _jar_artifact_impl(ctx):
-              |    netrc = read_netrc(ctx, "${model.getAuthFile.get}")
-              |    auth = use_netrc(netrc, ctx.attr.urls, {})
-              |""".stripMargin
-        else "def _jar_artifact_impl(ctx):"
+      s"""|load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_netrc", "read_user_netrc", "use_netrc")
+          |
+          |def _get_auth(ctx, urls):
+          |    netrc = {}
+          |    if 'netrc' in dir(ctx.attr):""".stripMargin
+      ${
+        if(model.hasAuthFile) "        netrc = read_netrc(ctx, "${model.getAuthFile.get}")"
+        else                  "        netrc = read_netrc(ctx, ctx.attr.netrc)"
       }
-         |    jar_name = "%s.jar" % ctx.name
-         |    ctx.download(
-         |        output = ctx.path("jar/%s" % jar_name),
-         |        url = ctx.attr.urls,
-         |        sha256 = ctx.attr.sha256,
-         |        executable = False${ifAuth(",\n        auth = auth")}
-         |    )
-         |    src_name = "%s-sources.jar" % ctx.name
-         |    srcjar_attr = ""
-         |    has_sources = len(ctx.attr.src_urls) != 0
-         |    if has_sources:${ifAuth("\n        src_auth = use_netrc(netrc, ctx.attr.src_urls, {})")}
-         |        ctx.download(
-         |            output = ctx.path("jar/%s" % src_name),
-         |            url = ctx.attr.src_urls,
-         |            sha256 = ctx.attr.src_sha256,
-         |            executable = False${ifAuth(",\n            auth = src_auth")}
-         |        )""".stripMargin
+          |    else:
+          |        netrc = read_user_netrc(ctx)
+          |    return use_netrc(netrc, urls, {})
+          |
+          |def _jar_artifact_impl(ctx):
+          |    jar_name = "%s.jar" % ctx.name
+          |    ctx.download(
+          |        output = ctx.path("jar/%s" % jar_name),
+          |        url = ctx.attr.urls,
+          |        sha256 = ctx.attr.sha256,
+          |        executable = False,
+          |        auth = _get_auth(ctx, ctx.attr.urls)
+          |    )
+          |    src_name = "%s-sources.jar" % ctx.name
+          |    srcjar_attr = ""
+          |    has_sources = len(ctx.attr.src_urls) != 0
+          |    if has_sources:
+          |        ctx.download(
+          |            output = ctx.path("jar/%s" % src_name),
+          |            url = ctx.attr.src_urls,
+          |            sha256 = ctx.attr.src_sha256,
+          |            executable = False,
+          |            auth = _get_auth(ctx, ctx.attr.src_urls)
+          |        )""".stripMargin
 
     s"""# Do not edit. bazel-deps autogenerates this file from $depsFile.
        |$jarArtifactImpl


### PR DESCRIPTION
I have come across this problem at work and I needed to be able to generate a workspace.bzl that includes some kind of way to read my .netrc file without specifying a path to it in the `authFile` parameter, because this will never ever be the same constant path on developer workstations and our CICD.

This PR sums up the necessary changes in order for `bazel-deps` to be able to do that.

Just to be clear:
- the authFile support in dependencies.yaml is not going away, it's still the dominant setting
- in absence of authFile, `_get_auth()` will try to get the contents of `~/.netrc` or if it doesn't exist return an empty dictionary

Also, this is my first time writing Scala code. Please please please please please tell me if I wrote the assembly of `jarArtifactImpl` with the variable part in between correctly.